### PR TITLE
hotfix: ヘルスチェックはフロントを見るよう修正

### DIFF
--- a/image/nginx.conf
+++ b/image/nginx.conf
@@ -56,14 +56,4 @@ server {
         proxy_force_ranges on;
         add_header X-Cache $upstream_cache_status;
     }
-
-    location /api/ping {
-        proxy_pass http://localhost:3000;
-        proxy_set_header Host $host;
-        proxy_http_version 1.1;
-        proxy_redirect off;
-        proxy_method 'POST';
-        proxy_set_header Content-Type 'application/json';
-        proxy_set_body '{}';
-    }
 }

--- a/infra/alb.tf
+++ b/infra/alb.tf
@@ -37,10 +37,6 @@ resource "aws_lb_target_group" "app" {
   port     = 80
   protocol = "HTTP"
   vpc_id   = aws_vpc.main.id
-
-  health_check {
-    path = "/api/ping"
-  }
 }
 
 resource "aws_lb_listener" "app" {


### PR DESCRIPTION
API で確認してたけど、どうもフロントだけ落ちるケースがある模様。
結果フロントは死んだのにヘルスチェックが通ってしまう。

これは困るのでヘルスチェックを戻す。