### PR TITLE
feat: オンデマンドインスタンスを追加

### DIFF
--- a/v2/infra/ec2.tf
+++ b/v2/infra/ec2.tf
@@ -155,7 +155,7 @@ resource "aws_autoscaling_group" "runners_v2" {
     }
 
     instances_distribution {
-      on_demand_percentage_above_base_capacity = "0"
+      on_demand_percentage_above_base_capacity = "1"
       spot_allocation_strategy                 = "price-capacity-optimized"
       spot_instance_pools                      = 0
     }


### PR DESCRIPTION
AWS のキャパシティ低下により、スポットインスタンスの確保の失敗が続いてしまっている。
少なくとも1台はオンデマンドインスタンスを確保することで、可用性の低下を防ぐ。